### PR TITLE
Implicitly unwrap UIImages when loading

### DIFF
--- a/SwiftStitch/SwViewController.swift
+++ b/SwiftStitch/SwViewController.swift
@@ -49,7 +49,7 @@ class SwViewController: UIViewController, UIScrollViewDelegate {
             var image3 = UIImage(named:"pano_19_22_mid.jpg")
             var image4 = UIImage(named:"pano_19_25_mid.jpg")
             
-            var imageArray:[UIImage] = [image1,image2,image3,image4]
+            var imageArray:[UIImage!] = [image1,image2,image3,image4]
             
             var stitchedImage:UIImage = CVWrapper.processWithArray(imageArray) as UIImage
             


### PR DESCRIPTION
Current code doesn't compile "out-of-box", probably because of Swift syntax changes. I get the following error:

![screen shot 2015-01-04 at 4 34 54 pm](https://cloud.githubusercontent.com/assets/4293969/5606144/68341ed0-9431-11e4-8896-9cb46005a2b8.png)

Simply implicitly unwrapping UIImages fixes the problem. 